### PR TITLE
Added PNG renderer

### DIFF
--- a/lib/eqrcode.ex
+++ b/lib/eqrcode.ex
@@ -86,4 +86,21 @@ defmodule EQRCode do
   Default options are `[color: "#000", shape: "square"]`.
   """
   defdelegate svg(matrix, options \\ []), to: EQRCode.SVG
+
+
+  @doc """
+  ```elixir
+  qr_code_content
+  |> EQRCode.encode()
+  |> EQRCode.png(color: <<255, 0, 255>>, width: 200)
+  ```
+
+  You can specify the following attributes of the QR code:
+
+  * `color`: In binary format. The default is `<<0, 0, 0>>`
+  * `width`: The width of the QR code in pixel. (the actual size may vary, due to the number of modules in the code)
+
+  By default, QR code size will be dynamically generated based on the input string.
+  """
+  defdelegate png(matrix, options \\ []), to: EQRCode.PNG
 end

--- a/lib/eqrcode/matrix.ex
+++ b/lib/eqrcode/matrix.ex
@@ -419,4 +419,12 @@ defmodule EQRCode.Matrix do
   defp available?(matrix, {x, y}) do
     get_in(matrix, [Access.elem(x), Access.elem(y)]) == nil
   end
+
+  @doc """
+  Get matrix size.
+  """
+  @spec size(t()) :: integer()
+  def size(%__MODULE__{matrix: matrix}) do
+    matrix |> Tuple.to_list() |> Enum.count()
+  end
 end

--- a/lib/eqrcode/png.ex
+++ b/lib/eqrcode/png.ex
@@ -1,0 +1,91 @@
+defmodule EQRCode.PNG do
+  @moduledoc """
+  Render the QR Code matrix in PNG format
+
+  ```elixir
+  qr_code_content
+  |> EQRCode.encode()
+  |> EQRCode.png()
+  ```
+
+  You can specify the following attributes of the QR code:
+
+  * `color`: In binary format. The default is `<<0, 0, 0>>`
+  * `width`: The width of the QR code in pixel. (the actual size may vary, due to the number of modules in the code)
+
+  By default, QR code size will be dynamically generated based on the input string.
+  """
+
+  alias EQRCode.Matrix
+
+  @defaults %{
+    color: <<0, 0, 0>>,
+    module_size: 11
+  }
+
+  @png_signature <<137, 80, 78, 71, 13, 10, 26, 10>>
+
+  @doc """
+  Return the PNG binary representation of the QR Code
+  """
+  @spec png(Matrix.t(), map() | Keyword.t()) :: String.t()
+  def png(%Matrix{matrix: matrix} = m, options \\ []) do
+    matrix_size = Matrix.size(m)
+    options = normalize_options(options, matrix_size)
+    pixel_size = matrix_size * options[:module_size]
+
+    ihdr = png_chunk("IHDR", <<pixel_size::32, pixel_size::32, 8::8, 2::8, 0::24>>)
+    idat = png_chunk("IDAT", pixels(matrix, options))
+    iend = png_chunk("IEND", "")
+
+    [@png_signature, ihdr, idat, iend]
+    |> List.flatten()
+    |> Enum.join()
+  end
+
+  defp normalize_options(options, matrix_size) do
+    options
+    |> Enum.into(@defaults)
+    |> calc_module_size(matrix_size)
+  end
+
+  defp calc_module_size(%{width: width} = options, matrix_size) when is_integer(width) do
+    size = (width / matrix_size) |> Float.round() |> trunc()
+    Map.put(options, :module_size, size)
+  end
+
+  defp calc_module_size(options, _matrix_size), do: options
+
+  defp png_chunk(type, binary) do
+    length = byte_size(binary)
+    crc = :erlang.crc32(type <> binary)
+
+    [<<length::32>>, type, binary, <<crc::32>>]
+  end
+
+  defp pixels(matrix, options) do
+    matrix
+    |> Tuple.to_list()
+    |> Stream.map(&row_pixels(&1, options))
+    |> Enum.join()
+    |> :zlib.compress()
+  end
+
+  defp row_pixels(row, %{module_size: module_size} = options) do
+    pixels =
+      row
+      |> Tuple.to_list()
+      |> Enum.map(&module_pixels(&1, options))
+      |> Enum.join()
+
+    :binary.copy(<<0>> <> pixels, module_size)
+  end
+
+  defp module_pixels(0, %{module_size: module_size}) do
+    :binary.copy(<<255, 255, 255>>, module_size)
+  end
+
+  defp module_pixels(1, %{color: color, module_size: module_size}) do
+    :binary.copy(color, module_size)
+  end
+end

--- a/lib/eqrcode/svg.ex
+++ b/lib/eqrcode/svg.ex
@@ -25,9 +25,9 @@ defmodule EQRCode.SVG do
   Return the SVG format of the QR Code
   """
   @spec svg(Matrix.t(), map() | Keyword.t()) :: String.t()
-  def svg(%Matrix{matrix: matrix}, options \\ []) do
+  def svg(%Matrix{matrix: matrix} = m, options \\ []) do
     options = options |> Enum.map(& &1)
-    matrix_size = matrix |> Tuple.to_list() |> Enum.count()
+    matrix_size = Matrix.size(m)
     svg_options = options |> Map.new() |> set_svg_options(matrix_size)
     dimension = matrix_size * svg_options[:module_size]
 


### PR DESCRIPTION
Hi, I needed to generate QR code as PNG to send via email.

It's loosely based on https://gitlab.com/Pacodastre/qrcode code, but heavily refactored to fit my needs.

PNG renderer accepts 2 options: `width` and `color` (in binary RGB format).

Unfortunately, `width` doesn't work as expected most of time, because I can't have float values for pixel sizes, therefore this option is only an approximation of the final size.