### PR TITLE
Reintroduce ASCII rendering

### DIFF
--- a/lib/eqrcode.ex
+++ b/lib/eqrcode.ex
@@ -87,7 +87,6 @@ defmodule EQRCode do
   """
   defdelegate svg(matrix, options \\ []), to: EQRCode.SVG
 
-
   @doc """
   ```elixir
   qr_code_content
@@ -103,4 +102,13 @@ defmodule EQRCode do
   By default, QR code size will be dynamically generated based on the input string.
   """
   defdelegate png(matrix, options \\ []), to: EQRCode.PNG
+
+  @doc """
+  ```elixir
+  qr_code_content
+  |> EQRCode.encode()
+  |> EQRCode.render()
+  ```
+  """
+  defdelegate render(matrix), to: EQRCode.Render
 end

--- a/lib/eqrcode/render.ex
+++ b/lib/eqrcode/render.ex
@@ -1,0 +1,46 @@
+defmodule EQRCode.Render do
+  @moduledoc """
+  Render the QR Code matrix.
+
+  Taken essentially verbatim from https://github.com/sunboshan/qrcode
+  """
+
+  @doc """
+  Render the QR Code to terminal.
+  """
+  @spec render(EQRCode.Matrix.t()) :: :ok
+  def render(%EQRCode.Matrix{matrix: matrix}) do
+    Tuple.to_list(matrix)
+    |> Stream.map(fn e ->
+      Tuple.to_list(e)
+      |> Enum.map(&do_render/1)
+    end)
+    |> Enum.intersperse("\n")
+    |> IO.puts()
+  end
+
+  defp do_render(1), do: "\e[40m  \e[0m"
+  defp do_render(0), do: "\e[0;107m  \e[0m"
+  defp do_render(nil), do: "\e[0;106m  \e[0m"
+  defp do_render(:data), do: "\e[0;102m  \e[0m"
+  defp do_render(:reserved), do: "\e[0;104m  \e[0m"
+
+  @doc """
+  Rotate the QR Code 90 degree clockwise and render to terminal.
+  """
+  @spec render2(EQRCode.Matrix.t()) :: :ok
+  def render2(%EQRCode.Matrix{matrix: matrix}) do
+    for(e <- Tuple.to_list(matrix), do: Tuple.to_list(e))
+    |> Enum.reverse()
+    |> transform()
+    |> Stream.map(fn e ->
+      Enum.map(e, &do_render/1)
+    end)
+    |> Enum.intersperse("\n")
+    |> IO.puts()
+  end
+
+  defp transform(matrix) do
+    for e <- Enum.zip(matrix), do: Tuple.to_list(e)
+  end
+end


### PR DESCRIPTION
Copied verbatim from the (essentially) upstream https://github.com/sunboshan/qrcode repo, this reintroduces the console rendering originally present in that project. I'd have just used that project, except that it's not released on hex.pm 

If possible, would *greatly* appreciate a patch release if this is merged so I can access console QR codes from a Hex native package (and thus declare it as a transitive dependency of a hex package). 