### PR TITLE
Implement alphanumeric encoding

### DIFF
--- a/lib/eqrcode.ex
+++ b/lib/eqrcode.ex
@@ -20,12 +20,12 @@ defmodule EQRCode do
   @doc """
   Encode the binary.
   """
-  @spec encode(binary, error_correction_level()) :: Matrix.t()
-  def encode(bin, error_correction_level \\ :l)
+  @spec encode(binary, error_correction_level(), atom()) :: Matrix.t()
+  def encode(bin, error_correction_level \\ :l, mode \\ :byte)
 
-  def encode(bin, error_correction_level) when byte_size(bin) <= 2952 do
+  def encode(bin, error_correction_level, mode) when byte_size(bin) <= 2952 do
     {version, error_correction_level, data} =
-      Encode.encode(bin, error_correction_level)
+      Encode.encode(bin, error_correction_level, mode)
       |> ReedSolomon.encode()
 
     Matrix.new(version, error_correction_level)
@@ -42,18 +42,18 @@ defmodule EQRCode do
     |> Matrix.draw_quite_zone()
   end
 
-  def encode(bin, _error_correction_level) when is_nil(bin) do
+  def encode(bin, _error_correction_level, _mode) when is_nil(bin) do
     raise(ArgumentError, message: "you must pass in some input")
   end
 
-  def encode(_, _),
+  def encode(_, _, _),
     do: raise(ArgumentError, message: "your input is too long. keep it under 2952 characters")
 
   @doc """
   Encode the binary with custom pattern bits. Only supports version 5.
   """
-  @spec encode(binary, error_correction_level(), bitstring) :: Matrix.t()
-  def encode(bin, error_correction_level, bits) when byte_size(bin) <= 106 do
+  @spec encode_with_pattern(binary, error_correction_level(), bitstring) :: Matrix.t()
+  def encode_with_pattern(bin, error_correction_level, bits) when byte_size(bin) <= 106 do
     {version, error_correction_level, data} =
       Encode.encode(bin, error_correction_level, bits)
       |> ReedSolomon.encode()
@@ -70,7 +70,7 @@ defmodule EQRCode do
     |> Matrix.draw_quite_zone()
   end
 
-  def encode(_, _, _), do: IO.puts("Binary too long.")
+  def encode_with_pattern(_, _, _), do: IO.puts("Binary too long.")
 
   @doc """
   ```elixir

--- a/lib/eqrcode/alphanumeric.ex
+++ b/lib/eqrcode/alphanumeric.ex
@@ -1,0 +1,60 @@
+defmodule EQRCode.Alphanumeric do
+
+  # Encoding table sourced from: https://www.thonky.com/qr-code-tutorial/alphanumeric-table
+  @lookup_table %{
+    ?0 => 0,
+    ?1 => 1,
+    ?2 => 2,
+    ?3 => 3,
+    ?4 => 4,
+    ?5 => 5,
+    ?6 => 6,
+    ?7 => 7,
+    ?8 => 8,
+    ?9 => 9,
+    ?A => 10,
+    ?B => 11,
+    ?C => 12,
+    ?D => 13,
+    ?E => 14,
+    ?F => 15,
+    ?G => 16,
+    ?H => 17,
+    ?I => 18,
+    ?J => 19,
+    ?K => 20,
+    ?L => 21,
+    ?M => 22,
+    ?N => 23,
+    ?O => 24,
+    ?P => 25,
+    ?Q => 26,
+    ?R => 27,
+    ?S => 28,
+    ?T => 29,
+    ?U => 30,
+    ?V => 31,
+    ?W => 32,
+    ?X => 33,
+    ?Y => 34,
+    ?Z => 35,
+    32 => 36,
+    ?$ => 37,
+    ?% => 38,
+    ?* => 39,
+    ?+ => 40,
+    ?- => 41,
+    ?. => 42,
+    ?/ => 43,
+    ?: => 44,
+  }
+
+  @spec from_binary(binary()) :: binary()
+  def from_binary(<<one, two, rest::binary>>) do
+    value = (45 * @lookup_table[one]) + @lookup_table[two]
+    <<value::11, from_binary(rest)::bitstring >>
+  end
+
+  def from_binary(<<one>>), do: <<@lookup_table[one]::6>>
+  def from_binary(<<>>), do: <<>>
+end


### PR DESCRIPTION
QR Codes can use a number of different encoding modes: https://en.wikipedia.org/wiki/QR_code#Storage

EQRCode currently only has byte mode encoding fully implemented. This PR adds support for the mode to be passed in as an argument to `encode`, and adds support for `:alphanumeric` mode. `:numeric` and `:kanji` remain unsupported.

Guide to implementing data encoding for QR Codes: https://www.thonky.com/qr-code-tutorial/data-encoding

Summary of changes:
* `EQRCode.encode/2` -> `EQRCode.encode/3`
* `EQRCode.encode/3` -> `EQRCode.encode_with_pattern/3`
* `EQRCode.Encode.encode/2` -> `EQRCode.Encode.encode/3`
* `EQRCode.Encode.encode/3` -> `EQRCode.Encode.encode_with_pattern/3`
* `EQRCode.Encode.version/2` -> `EQRCode.Encode.version/3`
* `EQRCode.Alphanumeric` - new module