### PR TITLE
fix docs source_ref

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule EQRCode.MixProject do
       ],
       main: "readme",
       source_url: @source_url,
+      source_ref: "v#{@version}",
       assets: "assets",
       formatters: ["html"]
     ]


### PR DESCRIPTION
This makes the source links work in Hexdocs, which is currently [defaulting](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-configuration) to the non-existent `main` branch.