### PR TITLE
Use `:background_color` instead of `fill: transparent`

### DIFF
--- a/lib/eqrcode/svg.ex
+++ b/lib/eqrcode/svg.ex
@@ -101,11 +101,11 @@ defmodule EQRCode.SVG do
     |> Enum.to_list()
   end
 
-  defp substitute(data, row_num, col_num, %{})
+  defp substitute(data, row_num, col_num, %{background_color: background_color})
        when is_nil(data) or data == 0 do
     %{}
     |> Map.put(:height, 1)
-    |> Map.put(:style, "fill: transparent;")
+    |> Map.put(:style, "fill: #{background_color};")
     |> Map.put(:width, 1)
     |> Map.put(:x, col_num)
     |> Map.put(:y, row_num)
@@ -120,7 +120,7 @@ defmodule EQRCode.SVG do
               (row_num <= 8 and col_num >= size - 9) do
     %{}
     |> Map.put(:height, 1)
-    |> Map.put(:style, "fill:#{color};")
+    |> Map.put(:style, "fill: #{color};")
     |> Map.put(:width, 1)
     |> Map.put(:x, col_num)
     |> Map.put(:y, row_num)
@@ -134,14 +134,14 @@ defmodule EQRCode.SVG do
     |> Map.put(:cx, col_num + radius)
     |> Map.put(:cy, row_num + radius)
     |> Map.put(:r, radius)
-    |> Map.put(:style, "fill:#{color};")
+    |> Map.put(:style, "fill: #{color};")
     |> draw_circle
   end
 
   defp substitute(1, row_num, col_num, %{color: color}) do
     %{}
     |> Map.put(:height, 1)
-    |> Map.put(:style, "fill:#{color};")
+    |> Map.put(:style, "fill: #{color};")
     |> Map.put(:width, 1)
     |> Map.put(:x, col_num)
     |> Map.put(:y, row_num)


### PR DESCRIPTION
First of all, thank you very much for the great package. Today, a colleague reported a small "issue" with the generated QR codes in SVG format. The display works perfectly in the browser, as well as in a limited range of graphic programs. However, in Adobe InDesign and Sketch, only a single black square is displayed.

This seems to be caused by the use of `fill: transparent`, which is not correctly interpreted by these graphic programs. In the browser, this is not an issue. A possible solution would be to allow `fill: transparent` here https://github.com/SiliconJungles/eqrcode/blob/0805d9841c1e434c53da778aacd55c3272340de9/lib/eqrcode/svg.ex#L108 to be replaced with `:background_color`. For example, one could specify `rgba(255,255,255,0)` as the `:background_color` and `rgba(0,0,0,255)` as the `:color`.